### PR TITLE
add quotes for commands/actions to allow snake-case names

### DIFF
--- a/www/api/data/components/component-qunit-tests/componentTemplates/componentQUnitActionRunner.html
+++ b/www/api/data/components/component-qunit-tests/componentTemplates/componentQUnitActionRunner.html
@@ -32,7 +32,7 @@
     var actions = {
 </pre>
 <pre class="action">
-    <span data-simply-field="action"></span> : <span data-simply-field="code" data-simply-transformer="indentCode" data-indent=8></span>
+    "<span data-simply-field="action"></span>" : <span data-simply-field="code" data-simply-transformer="indentCode" data-indent=8></span>
 </pre>
 <pre>
     };

--- a/www/api/data/components/component-qunit-tests/componentTemplates/componentQUnitCommandRunner.html
+++ b/www/api/data/components/component-qunit-tests/componentTemplates/componentQUnitCommandRunner.html
@@ -32,7 +32,7 @@
     var commands = {
 </pre>
 <pre class="command">
-    <span data-simply-field="command"></span> : <span data-simply-field="code" data-simply-transformer="indentCode" data-indent=8></span>
+    "<span data-simply-field="command"></span>" : <span data-simply-field="code" data-simply-transformer="indentCode" data-indent=8></span>
 </pre>
 <pre>
     };

--- a/www/api/data/components/preview-components/componentTemplates/simplyPreviewActions.html
+++ b/www/api/data/components/preview-components/componentTemplates/simplyPreviewActions.html
@@ -5,7 +5,7 @@
             <div data-simply-list="app.actions">
               <template>
 <pre class="action">
-            <span data-simply-field="action"></span> : <span data-simply-field="code" data-simply-transformer="indentCode" data-indent=12></span><span class="trailingComma">,</span>
+            "<span data-simply-field="action"></span>" : <span data-simply-field="code" data-simply-transformer="indentCode" data-indent=12></span><span class="trailingComma">,</span>
 </pre>
               </template>
             </div>

--- a/www/api/data/components/preview-components/componentTemplates/simplyPreviewCommands.html
+++ b/www/api/data/components/preview-components/componentTemplates/simplyPreviewCommands.html
@@ -5,7 +5,7 @@
             <div data-simply-list="app.commands">
               <template>
 <pre class="command">
-            <span data-simply-field="command"></span> : <span data-simply-field="code" data-simply-transformer="indentCode" data-indent=12></span><span class="trailingComma">,</span>
+            "<span data-simply-field="command"></span>" : <span data-simply-field="code" data-simply-transformer="indentCode" data-indent=12></span><span class="trailingComma">,</span>
 </pre>
               </template>
             </div>

--- a/www/api/data/generated.html
+++ b/www/api/data/generated.html
@@ -3042,7 +3042,7 @@
           var actions = {
       </pre>
       <pre class="action">
-          <span data-simply-field="action"></span> : <span data-simply-field="code" data-simply-transformer="indentCode" data-indent=8></span>
+          "<span data-simply-field="action"></span>" : <span data-simply-field="code" data-simply-transformer="indentCode" data-indent=8></span>
       </pre>
       <pre>
           };
@@ -3114,7 +3114,7 @@
           var commands = {
       </pre>
       <pre class="command">
-          <span data-simply-field="command"></span> : <span data-simply-field="code" data-simply-transformer="indentCode" data-indent=8></span>
+          "<span data-simply-field="command"></span>" : <span data-simply-field="code" data-simply-transformer="indentCode" data-indent=8></span>
       </pre>
       <pre>
           };
@@ -3507,7 +3507,7 @@
                   <div data-simply-list="app.actions">
                     <template>
       <pre class="action">
-                  <span data-simply-field="action"></span> : <span data-simply-field="code" data-simply-transformer="indentCode" data-indent=12></span><span class="trailingComma">,</span>
+                  "<span data-simply-field="action"></span>" : <span data-simply-field="code" data-simply-transformer="indentCode" data-indent=12></span><span class="trailingComma">,</span>
       </pre>
                     </template>
                   </div>
@@ -3560,7 +3560,7 @@
                   <div data-simply-list="app.commands">
                     <template>
       <pre class="command">
-                  <span data-simply-field="command"></span> : <span data-simply-field="code" data-simply-transformer="indentCode" data-indent=12></span><span class="trailingComma">,</span>
+                  "<span data-simply-field="command"></span>" : <span data-simply-field="code" data-simply-transformer="indentCode" data-indent=12></span><span class="trailingComma">,</span>
       </pre>
                     </template>
                   </div>

--- a/www/index.html
+++ b/www/index.html
@@ -2718,7 +2718,7 @@
     var actions = {
 </pre>
 <pre class="action">
-    <span data-simply-field="action"></span> : <span data-simply-field="code" data-simply-transformer="indentCode" data-indent=8></span>
+    "<span data-simply-field="action"></span>" : <span data-simply-field="code" data-simply-transformer="indentCode" data-indent=8></span>
 </pre>
 <pre>
     };
@@ -2787,7 +2787,7 @@
     var commands = {
 </pre>
 <pre class="command">
-    <span data-simply-field="command"></span> : <span data-simply-field="code" data-simply-transformer="indentCode" data-indent=8></span>
+    "<span data-simply-field="command"></span>" : <span data-simply-field="code" data-simply-transformer="indentCode" data-indent=8></span>
 </pre>
 <pre>
     };
@@ -3148,7 +3148,7 @@
 <div data-simply-list="app.actions">
 <template>
 <pre class="action">
-            <span data-simply-field="action"></span> : <span data-simply-field="code" data-simply-transformer="indentCode" data-indent=12></span><span class="trailingComma">,</span>
+            "<span data-simply-field="action"></span>" : <span data-simply-field="code" data-simply-transformer="indentCode" data-indent=12></span><span class="trailingComma">,</span>
 </pre>
 </template>
 </div>
@@ -3195,7 +3195,7 @@
 <div data-simply-list="app.commands">
 <template>
 <pre class="command">
-            <span data-simply-field="command"></span> : <span data-simply-field="code" data-simply-transformer="indentCode" data-indent=12></span><span class="trailingComma">,</span>
+            "<span data-simply-field="command"></span>" : <span data-simply-field="code" data-simply-transformer="indentCode" data-indent=12></span><span class="trailingComma">,</span>
 </pre>
 </template>
 </div>


### PR DESCRIPTION
Fixes #20. I checked if the problem would occur for dataSources, transformers and sorters which is not the case.
