### PR TITLE
Add files for use with NPM 

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,48 @@
+# The .npmignore file defines which files and folders should not be included in a package
+#
+# .npmignore files follow the same pattern rules as .gitignore files.
+# Like git, npm looks for .npmignore and .gitignore files in all subdirectories of your package, not only the root directory.
+#
+# By default, NPM ignores entries in the .gitignore file. However, since this .npmignore file exists, the .gitignore is not used.
+#
+# The following are always ignored:
+#
+# - .*.swp
+# - ._*
+# - .DS_Store
+# - .git
+# - .gitignore
+# - .hg
+# - .npmignore
+# - .npmrc
+# - .lock-wscript
+# - .svn
+# - .wafpickle-*
+# - config.gypi
+# - CVS
+# - npm-debug.log
+#
+# The following are never ignored:
+#
+# - package.json
+# - README (and its variants)
+# - CHANGELOG (and its variants)
+# - LICENSE / LICENCE
+#
+# For more details see: https://docs.npmjs.com/cli/v10/using-npm/developers#keeping-files-out-of-your-package
+
+# Directories to ignore
+.github/
+lib/
+www/api/
+www/data/
+www/files/
+www/simply-edit/
+
+# Files to ignore
+www/.htaccess
+www/generated.html
+000-default.conf
+docker-compose.yml
+Dockerfile
+TODO

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "author": "SimplyEdit",
+  "description": "Code editor in the SimplyEdit family",
+  "keywords": [
+    "code",
+    "ide",
+    "editor",
+    "lowcode",
+    "nocode",
+    "low-code",
+    "no-code"
+  ],
+  "license": "MIT",
+  "main": "index.html",
+  "name": "simplycode",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/SimplyEdit/simplycode.git"
+  }
+}


### PR DESCRIPTION
This MR makes it possible to install this project using:

```sh
npm install simplyedit/simplycode
```

As NPM allows installing from GitHub, the package does not have to be added to the NPM registry.

To allow this package to be loaded through NPM or Yarn, two files have been added:

- `package.json` The regular NPM package definition file
- `.npmignore` To tell NPM which files and folder to exclude from the package

The `.npmignore` file has been created under the premise that the "package" only needs to contain the bare minimum of files in order to use SimplyCode. Hence, no back-end is added, only the final (generated) HTML and some required assets.

It can be tested from this branch by using:

```sh
npm install simplyedit/simplycode#deploy/npm
```

This MR has been created to facilitate https://github.com/SimplyEdit/simplycode-electron/pull/1