### PR TITLE
Fetch and parse Imports  ZIP files

### DIFF
--- a/base-components/jszip/headHtml/js-zip.html
+++ b/base-components/jszip/headHtml/js-zip.html
@@ -1,0 +1,1 @@
+<script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1"></script>

--- a/base-components/jszip/meta.json
+++ b/base-components/jszip/meta.json
@@ -1,0 +1,1 @@
+{"id":"jszip","description":"Create, read and edit .zip files with Javascript"}

--- a/components/1-styling/componentCss/style.css
+++ b/components/1-styling/componentCss/style.css
@@ -237,3 +237,8 @@ header .simplycode-controls {
 .simplycode-editor-code textarea {
   margin-top: -1px;
 }
+strong.simplycode-module {
+  color: var(--simplycode-highlight-dark);
+  float: right;
+  padding-right: 5px;
+}

--- a/generated.html
+++ b/generated.html
@@ -949,6 +949,12 @@
       .simplycode-editor-code textarea {
         margin-top: -1px;
       }
+      strong.simplycode-module {
+        color: var(--simplycode-highlight-dark);
+        float: right;
+        padding-right: 5px;
+      }
+      
       /* simplycode-import-url (component/component-import-url) */
       .simplycode-editor-url input {
         width: 100%;
@@ -2313,6 +2319,80 @@
               return components;
             });
           },
+          // page/base-components
+          "listMergedBaseComponents" : async function() {
+            let moduleComponents;
+            let localComponents;
+          
+            try {
+              moduleComponents = await simplyDataApi.listSimplyModuleBaseComponents();
+            } catch(e) {
+              moduleComponents = [];
+            }
+          
+            try {
+              localComponents = await simplyDataApi.listBaseComponents();
+            } catch(e) {
+              localComponents = [];
+            } 
+            
+            let componentIndex = {};
+            let result = [];
+          
+            moduleComponents.forEach(function(component) {
+              componentIndex[component.id] = component;
+              component.imported = true;
+              result.push(component);
+            });
+          
+            localComponents.forEach(function(localComponent) {
+              if (typeof componentIndex[localComponent.id] !== "undefined") {
+                // FIXME: Merge the module + local component;
+                let mergedComponent = {};
+                
+                componentIndex[localComponent.id].contents.forEach(function(componentPart) {
+                  if (typeof mergedComponent[componentPart.id] === "undefined") {
+                    mergedComponent[componentPart.id] = {};
+                  }
+                  let parts = JSON.parse(componentPart.contents);
+                  let nameField = simplyApp.actions.getComponentNameField(componentPart.id);
+                  if (Array.isArray(parts)) {
+                    parts.forEach(function(part) {
+                      mergedComponent[componentPart.id][part[nameField]] = part;
+                    });
+                  }
+                });
+                localComponent.contents.forEach(function(componentPart) {
+                  if (typeof mergedComponent[componentPart.id] === "undefined") {
+                    mergedComponent[componentPart.id] = {};
+                  }
+                  let parts = JSON.parse(componentPart.contents);
+                  let nameField = simplyApp.actions.getComponentNameField(componentPart.id);
+                  if (Array.isArray(parts)) {
+                    parts.forEach(function(part) {
+                      mergedComponent[componentPart.id][part[nameField]] = part;
+                    });
+                  }
+                });
+                
+                componentIndex[localComponent.id].contents = [];
+                Object.keys(mergedComponent).forEach(function(componentPart) {
+                  let content = [];
+                  Object.values(mergedComponent[componentPart]).forEach(function(part) {
+                    content.push(part);
+                  });
+                  let mergedPart = {
+                    "id" : componentPart,
+                    "contents" : JSON.stringify(content)
+                  };
+                  componentIndex[localComponent.id].contents.push(mergedPart);
+                });
+              } else {
+                result.push(localComponent);
+              }
+            });
+            return result;
+          },
           // page/builder
           "deleteBuilder" : function(component) {
             return simplyRawApi.delete("builders/" + component)
@@ -2449,6 +2529,80 @@
               return components;
             });
           },
+          // page/component-list
+          "listMergedComponents" : async function() {
+            let moduleComponents;
+            let localComponents;
+          
+            try {
+              moduleComponents = await simplyDataApi.listSimplyModuleComponents();
+            } catch(e) {
+              moduleComponents = [];
+            }
+          
+            try {
+              localComponents = await simplyDataApi.listComponents();
+            } catch(e) {
+              localComponents = [];
+            } 
+            
+            let componentIndex = {};
+            let result = [];
+          
+            moduleComponents.forEach(function(component) {
+              componentIndex[component.id] = component;
+              component.imported = true;
+              result.push(component);
+            });
+          
+            localComponents.forEach(function(localComponent) {
+              if (typeof componentIndex[localComponent.id] !== "undefined") {
+                // FIXME: Merge the module + local component;
+                let mergedComponent = {};
+                
+                componentIndex[localComponent.id].contents.forEach(function(componentPart) {
+                  if (typeof mergedComponent[componentPart.id] === "undefined") {
+                    mergedComponent[componentPart.id] = {};
+                  }
+                  let parts = JSON.parse(componentPart.contents);
+                  let nameField = simplyApp.actions.getComponentNameField(componentPart.id);
+                  if (Array.isArray(parts)) {
+                    parts.forEach(function(part) {
+                      mergedComponent[componentPart.id][part[nameField]] = part;
+                    });
+                  }
+                });
+                localComponent.contents.forEach(function(componentPart) {
+                  if (typeof mergedComponent[componentPart.id] === "undefined") {
+                    mergedComponent[componentPart.id] = {};
+                  }
+                  let parts = JSON.parse(componentPart.contents);
+                  let nameField = simplyApp.actions.getComponentNameField(componentPart.id);
+                  if (Array.isArray(parts)) {
+                    parts.forEach(function(part) {
+                      mergedComponent[componentPart.id][part[nameField]] = part;
+                    });
+                  }
+                });
+                
+                componentIndex[localComponent.id].contents = [];
+                Object.keys(mergedComponent).forEach(function(componentPart) {
+                  let content = [];
+                  Object.values(mergedComponent[componentPart]).forEach(function(part) {
+                    content.push(part);
+                  });
+                  let mergedPart = {
+                    "id" : componentPart,
+                    "contents" : JSON.stringify(content)
+                  };
+                  componentIndex[localComponent.id].contents.push(mergedPart);
+                });
+              } else {
+                result.push(localComponent);
+              }
+            });
+            return result;
+          },
           // page/import
           "deleteImport" : function(component) {
             return simplyRawApi.delete("imports/" + component)
@@ -2518,6 +2672,96 @@
             });
           },
           // page/imports
+          "listSimplyModuleBaseComponents" : function() {
+            return simplyRawApi.get("simply-modules")
+              .then(function(response) {
+              if (response.status === 200) {
+                return response.json();
+              }
+              throw new Error("listSimplyModules failed", response.status);
+            })
+              .then(function(simplyModules) {
+              let components = [];
+              simplyModules.forEach(function(moduleGroup) {
+                moduleGroup.contents.forEach(function(module) {
+                  module.contents.forEach(function(moduleComponentCategory) {
+                    switch(moduleComponentCategory.id) {
+                      case "base-components":
+                        moduleComponentCategory.contents.forEach(function(component) {
+                          simplyDataApi.mergeComponent(component.contents);
+                          component.description = component.contents.description;
+                          component.baseType = 'baseComponent';
+                          components.push(component);
+                        });
+                      break;
+                    }
+                  });
+                });
+              });
+              return components;
+            });
+          },
+          // page/imports
+          "listSimplyModuleComponents" : function() {
+            return simplyRawApi.get("simply-modules")
+              .then(function(response) {
+              if (response.status === 200) {
+                return response.json();
+              }
+              throw new Error("listSimplyModules failed", response.status);
+            })
+              .then(function(simplyModules) {
+              let components = [];
+              simplyModules.forEach(function(moduleGroup) {
+                moduleGroup.contents.forEach(function(module) {
+                  module.contents.forEach(function(moduleComponentCategory) {
+                    switch(moduleComponentCategory.id) {
+                      case "components":
+                        moduleComponentCategory.contents.forEach(function(component) {
+                          simplyDataApi.mergeComponent(component.contents);
+                          component.description = component.contents.description;
+                          component.baseType = 'component';
+                          components.push(component);
+                        });
+                      break;
+                    }
+                  });
+                });
+              });
+              return components;
+            });
+          },
+          // page/imports
+          "listSimplyModulePages" : function() {
+            return simplyRawApi.get("simply-modules")
+              .then(function(response) {
+              if (response.status === 200) {
+                return response.json();
+              }
+              throw new Error("listSimplyModules failed", response.status);
+            })
+              .then(function(simplyModules) {
+              let components = [];
+              simplyModules.forEach(function(moduleGroup) {
+                moduleGroup.contents.forEach(function(module) {
+                  module.contents.forEach(function(moduleComponentCategory) {
+                    switch(moduleComponentCategory.id) {
+                      case "components":
+                        moduleComponentCategory.contents.forEach(function(component) {
+                          simplyDataApi.mergeComponent(component.contents);
+                          component.description = component.contents.description;
+                          component.baseType = 'page';
+                          components.push(component);
+                        });
+                      break;
+                    }
+                  });
+                });
+              });
+              return components;
+            });
+          },
+          // page/imports
           "listSimplyModules" : function() {
             return simplyRawApi.get("simply-modules")
               .then(function(response) {
@@ -2528,11 +2772,8 @@
             })
             .then(function(simplyModules) {
               simplyModules.forEach(function(moduleGroup) {
-                console.log(moduleGroup.id); // test-import
                 moduleGroup.contents.forEach(function(module) {
-                  console.log(module.id); // test
                   module.contents.forEach(function(moduleComponentCategory) {
-                    console.log(moduleComponentCategory.id); // base-components
                     switch(moduleComponentCategory.id) {
                       case "components":
                         moduleComponentCategory.contents.forEach(function(component) {
@@ -2688,6 +2929,80 @@
                 throw new Error("savePageFramePart failed", response.status);
               });
             });
+          },
+          // page/pages
+          "listMergedPages" : async function() {
+            let moduleComponents;
+            let localComponents;
+          
+            try {
+              moduleComponents = await simplyDataApi.listSimplyModulePages();
+            } catch(e) {
+              moduleComponents = [];
+            }
+          
+            try {
+              localComponents = await simplyDataApi.listPages();
+            } catch(e) {
+              localComponents = [];
+            } 
+            
+            let componentIndex = {};
+            let result = [];
+          
+            moduleComponents.forEach(function(component) {
+              componentIndex[component.id] = component;
+              component.imported = true;
+              result.push(component);
+            });
+          
+            localComponents.forEach(function(localComponent) {
+              if (typeof componentIndex[localComponent.id] !== "undefined") {
+                // FIXME: Merge the module + local component;
+                let mergedComponent = {};
+                
+                componentIndex[localComponent.id].contents.forEach(function(componentPart) {
+                  if (typeof mergedComponent[componentPart.id] === "undefined") {
+                    mergedComponent[componentPart.id] = {};
+                  }
+                  let parts = JSON.parse(componentPart.contents);
+                  let nameField = simplyApp.actions.getComponentNameField(componentPart.id);
+                  if (Array.isArray(parts)) {
+                    parts.forEach(function(part) {
+                      mergedComponent[componentPart.id][part[nameField]] = part;
+                    });
+                  }
+                });
+                localComponent.contents.forEach(function(componentPart) {
+                  if (typeof mergedComponent[componentPart.id] === "undefined") {
+                    mergedComponent[componentPart.id] = {};
+                  }
+                  let parts = JSON.parse(componentPart.contents);
+                  let nameField = simplyApp.actions.getComponentNameField(componentPart.id);
+                  if (Array.isArray(parts)) {
+                    parts.forEach(function(part) {
+                      mergedComponent[componentPart.id][part[nameField]] = part;
+                    });
+                  }
+                });
+                
+                componentIndex[localComponent.id].contents = [];
+                Object.keys(mergedComponent).forEach(function(componentPart) {
+                  let content = [];
+                  Object.values(mergedComponent[componentPart]).forEach(function(part) {
+                    content.push(part);
+                  });
+                  let mergedPart = {
+                    "id" : componentPart,
+                    "contents" : JSON.stringify(content)
+                  };
+                  componentIndex[localComponent.id].contents.push(mergedPart);
+                });
+              } else {
+                result.push(localComponent);
+              }
+            });
+            return result;
           },
           // page/pages
           "listPages" : function() {
@@ -2934,7 +3249,7 @@
             },
             // page/base-components
             "listBaseComponents" : function() {
-              return simplyDataApi.listBaseComponents()
+              return simplyDataApi.listMergedBaseComponents()
                 .catch(function(error) {
                 return [];
               });
@@ -3012,7 +3327,7 @@
             },
             // page/component-list
             "listComponents" : function() {
-              return simplyDataApi.listComponents()
+              return simplyDataApi.listMergedComponents()
                 .catch(function(error) {
                 return [];
               });
@@ -3198,7 +3513,7 @@
             },
             // page/pages
             "listPages" : function() {
-              return simplyDataApi.listPages()
+              return simplyDataApi.listMergedPages()
                 .catch(function(error) {
                 return [];
               });
@@ -3217,44 +3532,6 @@
                   frame[part.id] = part.contents;
                 });
                 appData.pageFrame = frame;
-              })
-              .then(function() {
-                return simplyApp.actions.listSimplyModules()
-                .then(function(modules) {
-                  modules.forEach(function(module) {
-                    // test-import
-                    console.log(module);
-                    module.contents.forEach(function(moduleGroup) {
-                      // test
-                      moduleGroup.contents.forEach(function(moduleComponentCategory) {
-                        switch (moduleComponentCategory.id) {
-                          case "base-components":
-                          case "components":
-                          case "pages":
-                          case "builders":
-                          case "imports":
-                            moduleComponentCategory.contents.forEach(function(component) {
-                              component.contents.forEach(function(part) {
-                                if (part.id == "meta") {
-                                  return;
-                                };
-            
-                                if (typeof appData[part.id] === "undefined") {
-                                  appData[part.id] = [];
-                                }
-                                parts = JSON.parse(part.contents);
-                                parts.forEach(function(entry) {
-                                  entry.base = component.baseType + "/" + component.id;
-                                  appData[part.id].push(entry);
-                                });
-                              });
-                            });
-                          break;
-                        }
-                      });
-                    });
-                  });
-                });
               })
               .then(function() {
                 return simplyApp.actions.listBuilders()
@@ -5784,7 +6061,12 @@
       <div class="simplycode-component-list" data-simply-list="components">
         <template>
           <a class="simplycode-component-list-item" data-simply-command="navigate" href="#" data-simply-field="id" data-simply-content="fixed" data-simply-transformer="baseComponentLink">
-            <h3 data-simply-field="id"></h3>
+            <h3>
+              <span data-simply-field="id"></span>
+              <span data-simply-field="imported" data-simply-content="template" data-simply-default-value="false">
+                <template data-simply-template="true"><strong class="simplycode-module">Import</strong></template>
+              </span>
+            </h3>
             <p class="ds-margin-up" data-simply-field="description"></p>
           </a>
         </template>
@@ -5882,7 +6164,12 @@
       <div class="simplycode-component-list" data-simply-list="components">
         <template>
           <a class="simplycode-component-list-item" data-simply-command="navigate" href="#" data-simply-field="id" data-simply-content="fixed" data-simply-transformer="componentLink">
-            <h3 data-simply-field="id"></h3>
+            <h3>
+              <span data-simply-field="id"></span>
+              <span data-simply-field="imported" data-simply-content="template" data-simply-default-value="false">
+                <template data-simply-template="true"><strong class="simplycode-module">Import</strong></template>
+              </span>
+            </h3>
             <p class="ds-margin-up" data-simply-field="description"></p>
           </a>
         </template>
@@ -5992,7 +6279,12 @@
       <div class="simplycode-component-list" data-simply-list="components">
         <template>
           <a class="simplycode-component-list-item" data-simply-command="navigate" href="#" data-simply-field="id" data-simply-content="fixed" data-simply-transformer="pageLink">
-            <h3 data-simply-field="id"></h3>
+            <h3>
+              <span data-simply-field="id"></span>
+              <span data-simply-field="imported" data-simply-content="template" data-simply-default-value="false">
+                <template data-simply-template="true"><strong class="simplycode-module">Import</strong></template>
+              </span>
+            </h3>
             <p class="ds-margin-up" data-simply-field="description"></p>
           </a>
         </template>

--- a/generated.html
+++ b/generated.html
@@ -1250,6 +1250,9 @@
         src: local('Cocon'), url('/assets/fonts/CoconRegularFont.woff') format('woff');
       }
     </style>
+    <!-- js-zip (baseComponent/jszip) -->
+    <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1"></script>
+    
     <!-- /Head HTML -->
     <script>
       var simplyDataApi = {};
@@ -2959,6 +2962,82 @@
             // page/import
             "deleteImport" : function(component) {
               return simplyDataApi.deleteImport(component);
+            },
+            // page/import
+            "fetchImportUrls" : async function (component) {
+                // @TODO: Check if the URL is actually a ZIP file and not another type
+            
+                const zipProxyUrl = 'zithub.pother.ca'
+            
+                const imports = await simplyApp.actions.getImport(component)
+            
+                const importUrls = imports
+                    .filter(importItem => importItem.id === 'importUrls')
+                    .map(importItem => JSON.parse(importItem.contents))
+                    .flat(2)
+            
+                const fetches = importUrls.map(importDetails => {
+                    const url = new URL(importDetails.url)
+            
+                    // GitHub does not send CORS headers, so a custom build proxy is used
+                    if (url.hostname.endsWith('github.com')) {
+                        url.pathname = `${url.href}`
+                        url.hostname = zipProxyUrl
+                    }
+            
+                    return fetch(url)
+                })
+            
+                const responses = await Promise.all(fetches)
+            
+                const arrayBufferResponses = responses.map(async response => {
+                    let blob = await response.blob()
+            
+                    return await blob.arrayBuffer()
+                })
+            
+                const arrayBuffers = await Promise.all(arrayBufferResponses)
+            
+                const zipArchives = arrayBuffers.map(async arrayBuffer => {
+                    const files = {}
+            
+                    const zip = await JSZip.loadAsync(arrayBuffer)
+                    const zipFiles = Object.values(zip.files)
+            
+                    for (const file of zipFiles) {
+                        if (file.dir === false) {
+                            files[file.name] = await file.async('blob')
+                        }
+                    }
+            
+                    return files
+                })
+            
+                const archiveFiles = await Promise.all(zipArchives)
+            
+                // @CHECKME: Instead of a naked object, should FileList and File be used?
+            
+                const fileCollections = archiveFiles.map(async fileCollection => {
+                    for (const [ fileName, blob ] of Object.entries(fileCollection)) {
+                        const bytes = await blob.arrayBuffer()
+            
+                        let contents, type
+            
+                        try {
+                            type = 'text/plain;charset=utf-8'
+                            contents = new TextDecoder('utf-8', { fatal: true }).decode(bytes)
+                        } catch (e) {
+                            type = 'application/octet-stream'
+                            contents = blob
+                        }
+            
+                        fileCollection[fileName] = { contents, type }
+                    }
+            
+                    return fileCollection
+                })
+            
+                return await Promise.all(fileCollections)
             },
             // page/import
             "getImport" : function(component) {

--- a/generated.html
+++ b/generated.html
@@ -2517,6 +2517,64 @@
               return components;
             });
           },
+          // page/imports
+          "listSimplyModules" : function() {
+            return simplyRawApi.get("simply-modules")
+              .then(function(response) {
+              if (response.status === 200) {
+                return response.json();
+              }
+              throw new Error("listSimplyModules failed", response.status);
+            })
+            .then(function(simplyModules) {
+              simplyModules.forEach(function(moduleGroup) {
+                console.log(moduleGroup.id); // test-import
+                moduleGroup.contents.forEach(function(module) {
+                  console.log(module.id); // test
+                  module.contents.forEach(function(moduleComponentCategory) {
+                    console.log(moduleComponentCategory.id); // base-components
+                    switch(moduleComponentCategory.id) {
+                      case "components":
+                        moduleComponentCategory.contents.forEach(function(component) {
+                          simplyDataApi.mergeComponent(component.contents);
+                          component.description = component.contents.description;
+                          component.baseType = 'component';
+                        });
+                      break;
+                      case "base-components":
+                        moduleComponentCategory.contents.forEach(function(component) {
+                          simplyDataApi.mergeComponent(component.contents);
+                          component.description = component.contents.description;
+                          component.baseType = 'baseComponent';
+                        });
+                      break;
+                      case "pages":
+                        moduleComponentCategory.contents.forEach(function(component) {
+                          simplyDataApi.mergeComponent(component.contents);
+                          component.description = component.contents.description;
+                          component.baseType = 'page';
+                        });
+                      break;
+                      case "builders":
+                        moduleComponentCategory.contents.forEach(function(component) {
+                          simplyDataApi.mergeComponent(component.contents);
+                          component.description = component.contents.description;
+                          component.baseType = 'builder';
+                        });
+                      case "imports":
+                        moduleComponentCategory.contents.forEach(function(component) {
+                          simplyDataApi.mergeComponent(component.contents);
+                          component.description = component.contents.description;
+                          component.baseType = 'import';
+                        });
+                      break;
+                    }
+                  });
+                });
+              });
+              return simplyModules;
+            });
+          },
           // page/page
           "deletePage" : function(component) {
             return simplyRawApi.delete("pages/" + component)
@@ -3074,6 +3132,13 @@
                 return [];
               });
             },
+            // page/imports
+            "listSimplyModules" : function() {
+              return simplyDataApi.listSimplyModules()
+                .catch(function(error) {
+                return [];
+              });
+            },
             // page/page
             "deletePage" : function(component) {
               return simplyDataApi.deletePage(component);
@@ -3152,6 +3217,44 @@
                   frame[part.id] = part.contents;
                 });
                 appData.pageFrame = frame;
+              })
+              .then(function() {
+                return simplyApp.actions.listSimplyModules()
+                .then(function(modules) {
+                  modules.forEach(function(module) {
+                    // test-import
+                    console.log(module);
+                    module.contents.forEach(function(moduleGroup) {
+                      // test
+                      moduleGroup.contents.forEach(function(moduleComponentCategory) {
+                        switch (moduleComponentCategory.id) {
+                          case "base-components":
+                          case "components":
+                          case "pages":
+                          case "builders":
+                          case "imports":
+                            moduleComponentCategory.contents.forEach(function(component) {
+                              component.contents.forEach(function(part) {
+                                if (part.id == "meta") {
+                                  return;
+                                };
+            
+                                if (typeof appData[part.id] === "undefined") {
+                                  appData[part.id] = [];
+                                }
+                                parts = JSON.parse(part.contents);
+                                parts.forEach(function(entry) {
+                                  entry.base = component.baseType + "/" + component.id;
+                                  appData[part.id].push(entry);
+                                });
+                              });
+                            });
+                          break;
+                        }
+                      });
+                    });
+                  });
+                });
               })
               .then(function() {
                 return simplyApp.actions.listBuilders()

--- a/pages/base-components/actions/listBaseComponents.js
+++ b/pages/base-components/actions/listBaseComponents.js
@@ -1,5 +1,5 @@
 function() {
-  return simplyDataApi.listBaseComponents()
+  return simplyDataApi.listMergedBaseComponents()
     .catch(function(error) {
     return [];
   });

--- a/pages/base-components/dataApi/listMergedBaseComponents.js
+++ b/pages/base-components/dataApi/listMergedBaseComponents.js
@@ -1,0 +1,73 @@
+async function() {
+  let moduleComponents;
+  let localComponents;
+
+  try {
+    moduleComponents = await simplyDataApi.listSimplyModuleBaseComponents();
+  } catch(e) {
+    moduleComponents = [];
+  }
+
+  try {
+    localComponents = await simplyDataApi.listBaseComponents();
+  } catch(e) {
+    localComponents = [];
+  } 
+  
+  let componentIndex = {};
+  let result = [];
+
+  moduleComponents.forEach(function(component) {
+    componentIndex[component.id] = component;
+    component.imported = true;
+    result.push(component);
+  });
+
+  localComponents.forEach(function(localComponent) {
+    if (typeof componentIndex[localComponent.id] !== "undefined") {
+      // FIXME: Merge the module + local component;
+      let mergedComponent = {};
+      
+      componentIndex[localComponent.id].contents.forEach(function(componentPart) {
+        if (typeof mergedComponent[componentPart.id] === "undefined") {
+          mergedComponent[componentPart.id] = {};
+        }
+        let parts = JSON.parse(componentPart.contents);
+        let nameField = simplyApp.actions.getComponentNameField(componentPart.id);
+        if (Array.isArray(parts)) {
+          parts.forEach(function(part) {
+            mergedComponent[componentPart.id][part[nameField]] = part;
+          });
+        }
+      });
+      localComponent.contents.forEach(function(componentPart) {
+        if (typeof mergedComponent[componentPart.id] === "undefined") {
+          mergedComponent[componentPart.id] = {};
+        }
+        let parts = JSON.parse(componentPart.contents);
+        let nameField = simplyApp.actions.getComponentNameField(componentPart.id);
+        if (Array.isArray(parts)) {
+          parts.forEach(function(part) {
+            mergedComponent[componentPart.id][part[nameField]] = part;
+          });
+        }
+      });
+      
+      componentIndex[localComponent.id].contents = [];
+      Object.keys(mergedComponent).forEach(function(componentPart) {
+        let content = [];
+        Object.values(mergedComponent[componentPart]).forEach(function(part) {
+          content.push(part);
+        });
+        let mergedPart = {
+          "id" : componentPart,
+          "contents" : JSON.stringify(content)
+        };
+        componentIndex[localComponent.id].contents.push(mergedPart);
+      });
+    } else {
+      result.push(localComponent);
+    }
+  });
+  return result;
+}

--- a/pages/base-components/pageTemplates/Base components.html
+++ b/pages/base-components/pageTemplates/Base components.html
@@ -3,7 +3,12 @@
   <div class="simplycode-component-list" data-simply-list="components">
     <template>
       <a class="simplycode-component-list-item" data-simply-command="navigate" href="#" data-simply-field="id" data-simply-content="fixed" data-simply-transformer="baseComponentLink">
-        <h3 data-simply-field="id"></h3>
+        <h3>
+          <span data-simply-field="id"></span>
+          <span data-simply-field="imported" data-simply-content="template" data-simply-default-value="false">
+            <template data-simply-template="true"><strong class="simplycode-module">Import</strong></template>
+          </span>
+        </h3>
         <p class="ds-margin-up" data-simply-field="description"></p>
       </a>
     </template>

--- a/pages/component-list/actions/listComponents.js
+++ b/pages/component-list/actions/listComponents.js
@@ -1,5 +1,5 @@
 function() {
-  return simplyDataApi.listComponents()
+  return simplyDataApi.listMergedComponents()
     .catch(function(error) {
     return [];
   });

--- a/pages/component-list/dataApi/listMergedComponents.js
+++ b/pages/component-list/dataApi/listMergedComponents.js
@@ -1,0 +1,73 @@
+async function() {
+  let moduleComponents;
+  let localComponents;
+
+  try {
+    moduleComponents = await simplyDataApi.listSimplyModuleComponents();
+  } catch(e) {
+    moduleComponents = [];
+  }
+
+  try {
+    localComponents = await simplyDataApi.listComponents();
+  } catch(e) {
+    localComponents = [];
+  } 
+  
+  let componentIndex = {};
+  let result = [];
+
+  moduleComponents.forEach(function(component) {
+    componentIndex[component.id] = component;
+    component.imported = true;
+    result.push(component);
+  });
+
+  localComponents.forEach(function(localComponent) {
+    if (typeof componentIndex[localComponent.id] !== "undefined") {
+      // FIXME: Merge the module + local component;
+      let mergedComponent = {};
+      
+      componentIndex[localComponent.id].contents.forEach(function(componentPart) {
+        if (typeof mergedComponent[componentPart.id] === "undefined") {
+          mergedComponent[componentPart.id] = {};
+        }
+        let parts = JSON.parse(componentPart.contents);
+        let nameField = simplyApp.actions.getComponentNameField(componentPart.id);
+        if (Array.isArray(parts)) {
+          parts.forEach(function(part) {
+            mergedComponent[componentPart.id][part[nameField]] = part;
+          });
+        }
+      });
+      localComponent.contents.forEach(function(componentPart) {
+        if (typeof mergedComponent[componentPart.id] === "undefined") {
+          mergedComponent[componentPart.id] = {};
+        }
+        let parts = JSON.parse(componentPart.contents);
+        let nameField = simplyApp.actions.getComponentNameField(componentPart.id);
+        if (Array.isArray(parts)) {
+          parts.forEach(function(part) {
+            mergedComponent[componentPart.id][part[nameField]] = part;
+          });
+        }
+      });
+      
+      componentIndex[localComponent.id].contents = [];
+      Object.keys(mergedComponent).forEach(function(componentPart) {
+        let content = [];
+        Object.values(mergedComponent[componentPart]).forEach(function(part) {
+          content.push(part);
+        });
+        let mergedPart = {
+          "id" : componentPart,
+          "contents" : JSON.stringify(content)
+        };
+        componentIndex[localComponent.id].contents.push(mergedPart);
+      });
+    } else {
+      result.push(localComponent);
+    }
+  });
+  return result;
+}

--- a/pages/component-list/pageTemplates/List components.html
+++ b/pages/component-list/pageTemplates/List components.html
@@ -3,7 +3,12 @@
   <div class="simplycode-component-list" data-simply-list="components">
     <template>
       <a class="simplycode-component-list-item" data-simply-command="navigate" href="#" data-simply-field="id" data-simply-content="fixed" data-simply-transformer="componentLink">
-        <h3 data-simply-field="id"></h3>
+        <h3>
+          <span data-simply-field="id"></span>
+          <span data-simply-field="imported" data-simply-content="template" data-simply-default-value="false">
+            <template data-simply-template="true"><strong class="simplycode-module">Import</strong></template>
+          </span>
+        </h3>
         <p class="ds-margin-up" data-simply-field="description"></p>
       </a>
     </template>

--- a/pages/import/actions/fetchImportUrls.js
+++ b/pages/import/actions/fetchImportUrls.js
@@ -1,0 +1,75 @@
+async function (component) {
+    // @TODO: Check if the URL is actually a ZIP file and not another type
+
+    const zipProxyUrl = 'zithub.pother.ca'
+
+    const imports = await simplyApp.actions.getImport(component)
+
+    const importUrls = imports
+        .filter(importItem => importItem.id === 'importUrls')
+        .map(importItem => JSON.parse(importItem.contents))
+        .flat(2)
+
+    const fetches = importUrls.map(importDetails => {
+        const url = new URL(importDetails.url)
+
+        // GitHub does not send CORS headers, so a custom build proxy is used
+        if (url.hostname.endsWith('github.com')) {
+            url.pathname = `${url.href}`
+            url.hostname = zipProxyUrl
+        }
+
+        return fetch(url)
+    })
+
+    const responses = await Promise.all(fetches)
+
+    const arrayBufferResponses = responses.map(async response => {
+        let blob = await response.blob()
+
+        return await blob.arrayBuffer()
+    })
+
+    const arrayBuffers = await Promise.all(arrayBufferResponses)
+
+    const zipArchives = arrayBuffers.map(async arrayBuffer => {
+        const files = {}
+
+        const zip = await JSZip.loadAsync(arrayBuffer)
+        const zipFiles = Object.values(zip.files)
+
+        for (const file of zipFiles) {
+            if (file.dir === false) {
+                files[file.name] = await file.async('blob')
+            }
+        }
+
+        return files
+    })
+
+    const archiveFiles = await Promise.all(zipArchives)
+
+    // @CHECKME: Instead of a naked object, should FileList and File be used?
+
+    const fileCollections = archiveFiles.map(async fileCollection => {
+        for (const [ fileName, blob ] of Object.entries(fileCollection)) {
+            const bytes = await blob.arrayBuffer()
+
+            let contents, type
+
+            try {
+                type = 'text/plain;charset=utf-8'
+                contents = new TextDecoder('utf-8', { fatal: true }).decode(bytes)
+            } catch (e) {
+                type = 'application/octet-stream'
+                contents = blob
+            }
+
+            fileCollection[fileName] = { contents, type }
+        }
+
+        return fileCollection
+    })
+
+    return await Promise.all(fileCollections)
+}

--- a/pages/imports/actions/listSimplyModules.js
+++ b/pages/imports/actions/listSimplyModules.js
@@ -1,0 +1,6 @@
+function() {
+  return simplyDataApi.listSimplyModules()
+    .catch(function(error) {
+    return [];
+  });
+}

--- a/pages/imports/dataApi/listSimplyModuleBaseComponents.js
+++ b/pages/imports/dataApi/listSimplyModuleBaseComponents.js
@@ -1,0 +1,29 @@
+function() {
+  return simplyRawApi.get("simply-modules")
+    .then(function(response) {
+    if (response.status === 200) {
+      return response.json();
+    }
+    throw new Error("listSimplyModules failed", response.status);
+  })
+    .then(function(simplyModules) {
+    let components = [];
+    simplyModules.forEach(function(moduleGroup) {
+      moduleGroup.contents.forEach(function(module) {
+        module.contents.forEach(function(moduleComponentCategory) {
+          switch(moduleComponentCategory.id) {
+            case "base-components":
+              moduleComponentCategory.contents.forEach(function(component) {
+                simplyDataApi.mergeComponent(component.contents);
+                component.description = component.contents.description;
+                component.baseType = 'baseComponent';
+                components.push(component);
+              });
+            break;
+          }
+        });
+      });
+    });
+    return components;
+  });
+}

--- a/pages/imports/dataApi/listSimplyModuleComponents.js
+++ b/pages/imports/dataApi/listSimplyModuleComponents.js
@@ -1,0 +1,29 @@
+function() {
+  return simplyRawApi.get("simply-modules")
+    .then(function(response) {
+    if (response.status === 200) {
+      return response.json();
+    }
+    throw new Error("listSimplyModules failed", response.status);
+  })
+    .then(function(simplyModules) {
+    let components = [];
+    simplyModules.forEach(function(moduleGroup) {
+      moduleGroup.contents.forEach(function(module) {
+        module.contents.forEach(function(moduleComponentCategory) {
+          switch(moduleComponentCategory.id) {
+            case "components":
+              moduleComponentCategory.contents.forEach(function(component) {
+                simplyDataApi.mergeComponent(component.contents);
+                component.description = component.contents.description;
+                component.baseType = 'component';
+                components.push(component);
+              });
+            break;
+          }
+        });
+      });
+    });
+    return components;
+  });
+}

--- a/pages/imports/dataApi/listSimplyModulePages.js
+++ b/pages/imports/dataApi/listSimplyModulePages.js
@@ -1,0 +1,29 @@
+function() {
+  return simplyRawApi.get("simply-modules")
+    .then(function(response) {
+    if (response.status === 200) {
+      return response.json();
+    }
+    throw new Error("listSimplyModules failed", response.status);
+  })
+    .then(function(simplyModules) {
+    let components = [];
+    simplyModules.forEach(function(moduleGroup) {
+      moduleGroup.contents.forEach(function(module) {
+        module.contents.forEach(function(moduleComponentCategory) {
+          switch(moduleComponentCategory.id) {
+            case "components":
+              moduleComponentCategory.contents.forEach(function(component) {
+                simplyDataApi.mergeComponent(component.contents);
+                component.description = component.contents.description;
+                component.baseType = 'page';
+                components.push(component);
+              });
+            break;
+          }
+        });
+      });
+    });
+    return components;
+  });
+}

--- a/pages/imports/dataApi/listSimplyModules.js
+++ b/pages/imports/dataApi/listSimplyModules.js
@@ -1,0 +1,57 @@
+function() {
+  return simplyRawApi.get("simply-modules")
+    .then(function(response) {
+    if (response.status === 200) {
+      return response.json();
+    }
+    throw new Error("listSimplyModules failed", response.status);
+  })
+  .then(function(simplyModules) {
+    simplyModules.forEach(function(moduleGroup) {
+      console.log(moduleGroup.id); // test-import
+      moduleGroup.contents.forEach(function(module) {
+        console.log(module.id); // test
+        module.contents.forEach(function(moduleComponentCategory) {
+          console.log(moduleComponentCategory.id); // base-components
+          switch(moduleComponentCategory.id) {
+            case "components":
+              moduleComponentCategory.contents.forEach(function(component) {
+                simplyDataApi.mergeComponent(component.contents);
+                component.description = component.contents.description;
+                component.baseType = 'component';
+              });
+            break;
+            case "base-components":
+              moduleComponentCategory.contents.forEach(function(component) {
+                simplyDataApi.mergeComponent(component.contents);
+                component.description = component.contents.description;
+                component.baseType = 'baseComponent';
+              });
+            break;
+            case "pages":
+              moduleComponentCategory.contents.forEach(function(component) {
+                simplyDataApi.mergeComponent(component.contents);
+                component.description = component.contents.description;
+                component.baseType = 'page';
+              });
+            break;
+            case "builders":
+              moduleComponentCategory.contents.forEach(function(component) {
+                simplyDataApi.mergeComponent(component.contents);
+                component.description = component.contents.description;
+                component.baseType = 'builder';
+              });
+            case "imports":
+              moduleComponentCategory.contents.forEach(function(component) {
+                simplyDataApi.mergeComponent(component.contents);
+                component.description = component.contents.description;
+                component.baseType = 'import';
+              });
+            break;
+          }
+        });
+      });
+    });
+    return simplyModules;
+  });
+}

--- a/pages/imports/dataApi/listSimplyModules.js
+++ b/pages/imports/dataApi/listSimplyModules.js
@@ -8,11 +8,8 @@ function() {
   })
   .then(function(simplyModules) {
     simplyModules.forEach(function(moduleGroup) {
-      console.log(moduleGroup.id); // test-import
       moduleGroup.contents.forEach(function(module) {
-        console.log(module.id); // test
         module.contents.forEach(function(moduleComponentCategory) {
-          console.log(moduleComponentCategory.id); // base-components
           switch(moduleComponentCategory.id) {
             case "components":
               moduleComponentCategory.contents.forEach(function(component) {

--- a/pages/pages/actions/listPages.js
+++ b/pages/pages/actions/listPages.js
@@ -1,5 +1,5 @@
 function() {
-  return simplyDataApi.listPages()
+  return simplyDataApi.listMergedPages()
     .catch(function(error) {
     return [];
   });

--- a/pages/pages/dataApi/listMergedPages.js
+++ b/pages/pages/dataApi/listMergedPages.js
@@ -1,0 +1,73 @@
+async function() {
+  let moduleComponents;
+  let localComponents;
+
+  try {
+    moduleComponents = await simplyDataApi.listSimplyModulePages();
+  } catch(e) {
+    moduleComponents = [];
+  }
+
+  try {
+    localComponents = await simplyDataApi.listPages();
+  } catch(e) {
+    localComponents = [];
+  } 
+  
+  let componentIndex = {};
+  let result = [];
+
+  moduleComponents.forEach(function(component) {
+    componentIndex[component.id] = component;
+    component.imported = true;
+    result.push(component);
+  });
+
+  localComponents.forEach(function(localComponent) {
+    if (typeof componentIndex[localComponent.id] !== "undefined") {
+      // FIXME: Merge the module + local component;
+      let mergedComponent = {};
+      
+      componentIndex[localComponent.id].contents.forEach(function(componentPart) {
+        if (typeof mergedComponent[componentPart.id] === "undefined") {
+          mergedComponent[componentPart.id] = {};
+        }
+        let parts = JSON.parse(componentPart.contents);
+        let nameField = simplyApp.actions.getComponentNameField(componentPart.id);
+        if (Array.isArray(parts)) {
+          parts.forEach(function(part) {
+            mergedComponent[componentPart.id][part[nameField]] = part;
+          });
+        }
+      });
+      localComponent.contents.forEach(function(componentPart) {
+        if (typeof mergedComponent[componentPart.id] === "undefined") {
+          mergedComponent[componentPart.id] = {};
+        }
+        let parts = JSON.parse(componentPart.contents);
+        let nameField = simplyApp.actions.getComponentNameField(componentPart.id);
+        if (Array.isArray(parts)) {
+          parts.forEach(function(part) {
+            mergedComponent[componentPart.id][part[nameField]] = part;
+          });
+        }
+      });
+      
+      componentIndex[localComponent.id].contents = [];
+      Object.keys(mergedComponent).forEach(function(componentPart) {
+        let content = [];
+        Object.values(mergedComponent[componentPart]).forEach(function(part) {
+          content.push(part);
+        });
+        let mergedPart = {
+          "id" : componentPart,
+          "contents" : JSON.stringify(content)
+        };
+        componentIndex[localComponent.id].contents.push(mergedPart);
+      });
+    } else {
+      result.push(localComponent);
+    }
+  });
+  return result;
+}

--- a/pages/pages/pageTemplates/Pages.html
+++ b/pages/pages/pageTemplates/Pages.html
@@ -3,7 +3,12 @@
   <div class="simplycode-component-list" data-simply-list="components">
     <template>
       <a class="simplycode-component-list-item" data-simply-command="navigate" href="#" data-simply-field="id" data-simply-content="fixed" data-simply-transformer="pageLink">
-        <h3 data-simply-field="id"></h3>
+        <h3>
+          <span data-simply-field="id"></span>
+          <span data-simply-field="imported" data-simply-content="template" data-simply-default-value="false">
+            <template data-simply-template="true"><strong class="simplycode-module">Import</strong></template>
+          </span>
+        </h3>
         <p class="ds-margin-up" data-simply-field="description"></p>
       </a>
     </template>

--- a/pages/publish/actions/getAppData.js
+++ b/pages/publish/actions/getAppData.js
@@ -13,6 +13,44 @@ function() {
     appData.pageFrame = frame;
   })
   .then(function() {
+    return simplyApp.actions.listSimplyModules()
+    .then(function(modules) {
+      modules.forEach(function(module) {
+        // test-import
+        console.log(module);
+        module.contents.forEach(function(moduleGroup) {
+          // test
+          moduleGroup.contents.forEach(function(moduleComponentCategory) {
+            switch (moduleComponentCategory.id) {
+              case "base-components":
+              case "components":
+              case "pages":
+              case "builders":
+              case "imports":
+                moduleComponentCategory.contents.forEach(function(component) {
+                  component.contents.forEach(function(part) {
+                    if (part.id == "meta") {
+                      return;
+                    };
+
+                    if (typeof appData[part.id] === "undefined") {
+                      appData[part.id] = [];
+                    }
+                    parts = JSON.parse(part.contents);
+                    parts.forEach(function(entry) {
+                      entry.base = component.baseType + "/" + component.id;
+                      appData[part.id].push(entry);
+                    });
+                  });
+                });
+              break;
+            }
+          });
+        });
+      });
+    });
+  })
+  .then(function() {
     return simplyApp.actions.listBuilders()
     .then(function(builders) {
       builders.forEach(function(builder) {

--- a/pages/publish/actions/getAppData.js
+++ b/pages/publish/actions/getAppData.js
@@ -17,7 +17,6 @@ function() {
     .then(function(modules) {
       modules.forEach(function(module) {
         // test-import
-        console.log(module);
         module.contents.forEach(function(moduleGroup) {
           // test
           moduleGroup.contents.forEach(function(moduleComponentCategory) {

--- a/pages/publish/actions/getAppData.js
+++ b/pages/publish/actions/getAppData.js
@@ -13,43 +13,6 @@ function() {
     appData.pageFrame = frame;
   })
   .then(function() {
-    return simplyApp.actions.listSimplyModules()
-    .then(function(modules) {
-      modules.forEach(function(module) {
-        // test-import
-        module.contents.forEach(function(moduleGroup) {
-          // test
-          moduleGroup.contents.forEach(function(moduleComponentCategory) {
-            switch (moduleComponentCategory.id) {
-              case "base-components":
-              case "components":
-              case "pages":
-              case "builders":
-              case "imports":
-                moduleComponentCategory.contents.forEach(function(component) {
-                  component.contents.forEach(function(part) {
-                    if (part.id == "meta") {
-                      return;
-                    };
-
-                    if (typeof appData[part.id] === "undefined") {
-                      appData[part.id] = [];
-                    }
-                    parts = JSON.parse(part.contents);
-                    parts.forEach(function(entry) {
-                      entry.base = component.baseType + "/" + component.id;
-                      appData[part.id].push(entry);
-                    });
-                  });
-                });
-              break;
-            }
-          });
-        });
-      });
-    });
-  })
-  .then(function() {
     return simplyApp.actions.listBuilders()
     .then(function(builders) {
       builders.forEach(function(builder) {


### PR DESCRIPTION
This MR adds the [JSZip](https://github.com/Stuk/jszip) library as a dependency (from a CDN for now) and logic to fetch and parse ZIP files for Imports.

It is not connected to a Command, but can be triggered from the console:

1. Create an import (for instance `simplycode-dummy-component) 
2. Add a URL (for instance `https://github.com/potherca-blog/simplycode-dummy-component/archive/refs/heads/main.zip`)
3. Call 
   ```js
   const fileCollections = await simplyApp.actions.fetchImportUrls('simplycode-dummy-component')
   ```

`fileCollections` will now contain an array with one object per fetched ZIP.

Because GitHub does not set CORS headers for ZIP files, a proxy is used https://zithub.pother.ca/

Requests for features and bugfixes can be added as a comment at [gist:05a59304a9adba9fd6d58320f36d5efe](https://gist.github.com/potherca/05a59304a9adba9fd6d58320f36d5efe/)

## Review questions:

This is a first working draft. Beside the follow-up actions stated below, the author of this MR has the following questions:

- Should a naked object be used for files and file-lists, or should [File](https://developer.mozilla.org/docs/Web/API/File) and [FileList](https://developer.mozilla.org/docs/Web/API/FileList) be used?
- There isn't really any error handling. Guidance where this is expected would be appreciated.
- Is this action in the right location? And if/when it is broken into smaller pieces, should parts live elsewhere?

## Follow-up actions

- [x] Load JSZip from a local file, so it also works offline
- [x] Break the action down into smaller parts
- [x] Anything that comes up in review